### PR TITLE
Changing `setWorkAllowed` call to conform to real machines when that is the case

### DIFF
--- a/Programs/monitor-system/api/gui/overview.lua
+++ b/Programs/monitor-system/api/gui/overview.lua
@@ -26,7 +26,9 @@ local machinesNotFound = {}
 
 local function createMachineWidget(address, name)
     local function update(self, statuses)
-        if not statuses.machineStatus.multiblockStatus[address] then
+        local status = statuses.machineStatus.multiblockStatus[address]
+
+        if not status then
             machinesNotFound[address] = "not found"
             local nMachinesNotFound = 0
             for _, _ in pairs(machinesNotFound) do
@@ -42,7 +44,7 @@ local function createMachineWidget(address, name)
         end
 
         machinesNotFound[address] = nil
-        for key, value in pairs(statuses.machineStatus.multiblockStatus[address]) do
+        for key, value in pairs(status) do
             self[key] = value
         end
     end

--- a/Programs/monitor-system/data/mock/mock-machine.lua
+++ b/Programs/monitor-system/data/mock/mock-machine.lua
@@ -30,7 +30,7 @@ function mockMachine:getMock(address, name)
     return self.mocks[address]
 end
 
-function mockMachine.setWorkAllowed(allow, self)
+function mockMachine:setWorkAllowed(allow)
     local mock = self:getMock(self.address, self.name)
     if mock.isBroken then
         mock.isBroken = false

--- a/Programs/monitor-system/domain/cleanroom/protect-recipes-usecase.lua
+++ b/Programs/monitor-system/domain/cleanroom/protect-recipes-usecase.lua
@@ -6,19 +6,37 @@ Alarm = require("api.sound.alarm")
 local function halt(machines)
     Alarm()
     for _, machine in ipairs(machines) do
-        machine.setWorkAllowed(false, machine)
+        local successfull =
+            pcall(
+            function()
+                machine.setWorkAllowed(false)
+            end
+        )
+        if (not successfull) then
+            machine:setWorkAllowed(false)
+        end
     end
 end
 
 local function resume(machines)
     for _, machine in ipairs(machines) do
-        machine.setWorkAllowed(true, machine)
+        local successfull =
+            pcall(
+            function()
+                machine.setWorkAllowed(true)
+            end
+        )
+        if (not successfull) then
+            machine:setWorkAllowed(true)
+        end
     end
 end
 
 local function exec(cleanroomAddresses)
     local cleanroom = Machine.getMachine(cleanroomAddresses.cleanroom, "Cleanroom")
-    if not cleanroom then return end
+    if not cleanroom then
+        return
+    end
     local machines = {}
     for name, address in pairs(cleanroomAddresses) do
         if name ~= "cleanroom" then
@@ -28,7 +46,16 @@ local function exec(cleanroomAddresses)
     if (tonumber(cleanroom:getEfficiencyPercentage()) < 100) then
         if (cleanroom:isWorkAllowed()) then
             halt(machines)
-            cleanroom.setWorkAllowed(false, cleanroom)
+
+            local successfull =
+                pcall(
+                function()
+                    cleanroom.setWorkAllowed(false)
+                end
+            )
+            if (not successfull) then
+                cleanroom:setWorkAllowed(false)
+            end
         end
     else
         resume(machines)

--- a/Programs/monitor-system/domain/multiblock/toggle-multiblock-work.lua
+++ b/Programs/monitor-system/domain/multiblock/toggle-multiblock-work.lua
@@ -6,9 +6,20 @@ Machine = require("data.datasource.machine")
 
 local function exec(address, name)
     local multiblock = Machine.getMachine(address, name)
-    if not multiblock then return end
+    if not multiblock then
+        return
+    end
     local workAllowed = multiblock:isWorkAllowed()
-    multiblock.setWorkAllowed(not workAllowed, multiblock)
+
+    local successfull =
+        pcall(
+        function()
+            multiblock.setWorkAllowed(not workAllowed)
+        end
+    )
+    if (not successfull) then
+        multiblock:setWorkAllowed(not workAllowed)
+    end
 end
 
 return exec


### PR DESCRIPTION
Real machines will not set the work if there are more parameters used