### PR TITLE
Changing missing machine warning to `machine.lua`

### DIFF
--- a/Programs/monitor-system/api/gui/overview.lua
+++ b/Programs/monitor-system/api/gui/overview.lua
@@ -22,28 +22,10 @@ local overview = {
         active = {}
     }
 }
-local machinesNotFound = {}
 
 local function createMachineWidget(address, name)
     local function update(self, statuses)
         local status = statuses.machineStatus.multiblockStatus[address]
-
-        if not status then
-            machinesNotFound[address] = "not found"
-            local nMachinesNotFound = 0
-            for _, _ in pairs(machinesNotFound) do
-                nMachinesNotFound = nMachinesNotFound + 1
-            end
-
-            Term.setCursor(1, 1)
-            Term.gpu().setBackground(Colors.black)
-            Term.gpu().setForeground(Colors.errorColor)
-            print("Failed to find the machine " .. address .. ". " .. nMachinesNotFound .. " machines not found.")
-
-            return
-        end
-
-        machinesNotFound[address] = nil
         for key, value in pairs(status) do
             self[key] = value
         end

--- a/Programs/monitor-system/data/datasource/machine.lua
+++ b/Programs/monitor-system/data/datasource/machine.lua
@@ -23,6 +23,7 @@ machine.states = {
     IDLE = {name = "IDLE", color = Colors.idleColor},
     OFF = {name = "OFF", color = Colors.offColor},
     BROKEN = {name = "BROKEN", color = Colors.errorColor},
+    MISSING = {name = "NOT FOUND", color = Colors.errorColor}
 }
 
 function machine.getMachine(address, name)
@@ -35,6 +36,8 @@ function machine.getMachine(address, name)
     -- end
 end
 
+local machinesNotFound = {}
+
 function machine:new(partialAdress, name)
     local mach = nil
 
@@ -42,9 +45,21 @@ function machine:new(partialAdress, name)
         pcall(
         function()
             mach = New(self, Component.proxy(Component.get(partialAdress)))
+            machinesNotFound[partialAdress] = nil
         end
     )
     if (not successfull and Filesystem.exists("/home/InfOS/.gitignore")) then
+        machinesNotFound[partialAdress] = "not found"
+        local nMachinesNotFound = 0
+        for _, _ in pairs(machinesNotFound) do
+            nMachinesNotFound = nMachinesNotFound + 1
+        end
+
+        Term.setCursor(1, 1)
+        Term.gpu().setBackground(Colors.black)
+        Term.gpu().setForeground(Colors.errorColor)
+        print("Failed to find the machine " .. partialAdress .. ". " .. nMachinesNotFound .. " machines not found.")
+
         mach = New(self, self.mock:new(partialAdress, name))
     end
 

--- a/Programs/monitor-system/domain/multiblock/get-multiblock-status-usecase.lua
+++ b/Programs/monitor-system/domain/multiblock/get-multiblock-status-usecase.lua
@@ -4,7 +4,15 @@ Machine = require("data.datasource.machine")
 
 local function exec(address, name)
     local multiblock = Machine.getMachine(address, name)
-    if not multiblock then return end
+    if not multiblock then
+        return {
+            progress = 0,
+            maxProgress = 0,
+            probablyUses = 0,
+            efficiencyPercentage = 0,
+            state = Machine.states.MISSING
+        }
+    end
     local problems = multiblock:getNumberOfProblems()
 
     local state = {}


### PR DESCRIPTION
Adding `missing` `state` to `machine.lua` and `getMultiblockStatusUsecase`